### PR TITLE
Containerizer listens only on localhost

### DIFF
--- a/Containerizer/Containerizer/Program.cs
+++ b/Containerizer/Containerizer/Program.cs
@@ -31,7 +31,7 @@ namespace Containerizer
                 int workerThreads, portFinishingThreads;
                 ThreadPool.GetMaxThreads(out workerThreads, out portFinishingThreads);
                 ThreadPool.SetMinThreads(workerThreads, portFinishingThreads);
-                using (WebApp.Start<Startup>("http://*:" + startOptions.Port + "/"))
+                using (WebApp.Start<Startup>("http://127.0.0.1:" + startOptions.Port + "/"))
                 {
                     logger.Info("containerizer.started", new Dictionary<string, object> { { "port", startOptions.Port }, { "machineIp", startOptions.MachineIp } });
                     ExitLatch.WaitOne();


### PR DESCRIPTION
There is no need for Containerizer to listen on all interfaces.